### PR TITLE
Retain answer order

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mdxcanvas"
-version = "0.1.8"
+version = "0.1.9"
 description = "A Canvas LMS API wrapper for maintaining content in markdown"
 authors = ["Gordon Bean <gbean@cs.byu.edu>", "Preston Raab <phr23@byu.edu>"]
 license = "MIT"


### PR DESCRIPTION
We were using answers = corrects + incorrects, which caused the correct answers to always appear first.

Also migrated to use md4's select, since css.filter is deprecated.