### PR TITLE
Add support for feedback comments on individual answers

### DIFF
--- a/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/load.py
+++ b/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/load.py
@@ -1,4 +1,4 @@
-load.py  # !/usr/bin/env python3
+# !/usr/bin/env python3
 from __future__ import annotations
 
 from pathlib import Path

--- a/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/questions/skill.md
+++ b/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/questions/skill.md
@@ -20,6 +20,12 @@ Use this reference when working with:
 - Use `<correct>` and `<incorrect>` tags exactly as shown for each type — structure varies by type.
 - Use `id` on questions generated programmatically so they can be updated without duplication.
 
+## Answer Feedback
+
+These question types support per-answer feedback:
+- `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` / `<incorrect>`
+- `true-false`: use `true_answer_comments="..."` and `false_answer_comments="..."` on `<question>`
+
 ---
 
 ## Common Question Attributes
@@ -78,9 +84,12 @@ Displays a block of instructional or contextual text. Does not require an answer
 ## `true-false`
 
 Presents a True/False question. Requires the `answer` attribute (`true` or `false`).
+Optional per-answer feedback may be provided with `true_answer_comments` and `false_answer_comments`.
 
 ```xml
-<question type="true-false" answer="true">
+<question type="true-false" answer="true"
+          true_answer_comments="Correct"
+          false_answer_comments="The sky is blue under normal daylight conditions.">
     Is the sky blue?
 </question>
 ```
@@ -89,14 +98,14 @@ Presents a True/False question. Requires the `answer` attribute (`true` or `fals
 
 ## `multiple-choice`
 
-Single-answer multiple choice. Requires at least one `<correct>` and one or more `<incorrect>` options.
+Single-answer multiple choice. Requires at least one `<correct>` and one or more `<incorrect>` options. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question type="multiple-choice">
     What is the capital of France?
 
-    <correct>Paris</correct>
-    <incorrect>London</incorrect>
+    <correct answer_comments="Exactly right">Paris</correct>
+    <incorrect answer_comments="London is the capital of the UK">London</incorrect>
     <incorrect>Berlin</incorrect>
     <incorrect>Madrid</incorrect>
 </question>
@@ -106,15 +115,15 @@ Single-answer multiple choice. Requires at least one `<correct>` and one or more
 
 ## `multiple-answers`
 
-Allows selection of multiple correct answers.
+Allows selection of multiple correct answers. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question type="multiple-answers">
     Which of the following are programming languages?
 
-    <correct>Python</correct>
+    <correct answer_comments="Yes">Python</correct>
     <correct>JavaScript</correct>
-    <incorrect>HTML</incorrect>
+    <incorrect answer_comments="HTML is markup, not a programming language">HTML</incorrect>
     <incorrect>CSS</incorrect>
 </question>
 ```

--- a/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/questions/skill.md
+++ b/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/questions/skill.md
@@ -22,9 +22,14 @@ Use this reference when working with:
 
 ## Answer Feedback
 
-These question types support per-answer feedback:
-- `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` / `<incorrect>`
-- `true-false`: use `true_answer_comments="..."` and `false_answer_comments="..."` on `<question>`
+Some question types support per-answer feedback that maps directly to the Canvas API:
+
+- `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` and `<incorrect>`
+- `matching`: use `answer_comments="..."` on `<pair>`
+- `fill-in-the-blank` and `fill-in-multiple-blanks`: use `answer_comments="..."` on `<correct>`
+- `numerical`: use `answer_comments="..."` on `<correct>`
+- `multiple-tf`: use `answer_comments="..."` on `<correct>` and `<incorrect>` to populate `correct-comments` on each generated true/false subquestion
+- `true-false`: use question-level `correct-comments` and `incorrect-comments`
 
 ---
 
@@ -84,12 +89,12 @@ Displays a block of instructional or contextual text. Does not require an answer
 ## `true-false`
 
 Presents a True/False question. Requires the `answer` attribute (`true` or `false`).
-Optional per-answer feedback may be provided with `true_answer_comments` and `false_answer_comments`.
+Feedback should be provided with the standard question-level `correct-comments` and `incorrect-comments` fields.
 
 ```xml
 <question type="true-false" answer="true"
-          true_answer_comments="Correct"
-          false_answer_comments="The sky is blue under normal daylight conditions.">
+          correct-comments="Correct"
+          incorrect-comments="The sky is blue under normal daylight conditions.">
     Is the sky blue?
 </question>
 ```
@@ -133,15 +138,15 @@ Allows selection of multiple correct answers. Optional per-answer feedback may b
 ## `matching`
 
 Students match items from two columns. Use `<pair>` for correct matches and optionally `<distractors>` for extra
-wrong-side items.
+wrong-side items. Optional per-pair feedback may be provided with `answer_comments`.
 
 ```xml
 <question type="matching">
     Match the following countries with their capitals.
 
-    <pair left="France" right="Paris"/>
-    <pair left="Germany" right="Berlin"/>
-    <pair left="Spain" right="Madrid"/>
+    <pair left="France" right="Paris" answer_comments="Paris is the capital of France." />
+    <pair left="Germany" right="Berlin" />
+    <pair left="Spain" right="Madrid" />
 
     <distractors>
         London
@@ -155,14 +160,14 @@ wrong-side items.
 
 ## `multiple-tf`
 
-Presents multiple True/False statements. Students select which are true.
+Presents multiple True/False statements. Students select which are true. Optional `answer_comments` on each `<correct>` / `<incorrect>` child becomes question-level feedback on the generated true/false subquestion.
 
 ```xml
 <question type="multiple-tf">
     Which of the following statements are true?
 
-    <correct>Python is a programming language.</correct>
-    <incorrect>HTML is a programming language.</incorrect>
+    <correct answer_comments="Yes, Python is a programming language.">Python is a programming language.</correct>
+    <incorrect answer_comments="No, HTML is markup.">HTML is a programming language.</incorrect>
     <correct>JavaScript can be used for web development.</correct>
     <incorrect>CSS is a programming language.</incorrect>
 </question>
@@ -172,13 +177,13 @@ Presents multiple True/False statements. Students select which are true.
 
 ## `fill-in-the-blank`
 
-A single blank the student must fill in. Use `[blank]` in the sentence and `<correct text="..." />` for valid answers.
+A single blank the student must fill in. Use `[blank]` in the sentence and `<correct text="..." />` for valid answers. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question type="fill-in-the-blank">
     The capital of France is [blank].
 
-    <correct text="Paris"/>
+    <correct text="Paris" answer_comments="Exactly right." />
 </question>
 ```
 
@@ -186,14 +191,14 @@ A single blank the student must fill in. Use `[blank]` in the sentence and `<cor
 
 ## `fill-in-multiple-blanks`
 
-Multiple named blanks. Each `<correct>` must specify the matching `blank` name.
+Multiple named blanks. Each `<correct>` must specify the matching `blank` name. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question type="fill-in-multiple-blanks">
     The U.S. flag has [stripes] stripes and [stars] stars.
 
-    <correct text="13" blank="stripes"/>
-    <correct text="50" blank="stars"/>
+    <correct text="13" blank="stripes" answer_comments="There are 13 original colonies." />
+    <correct text="50" blank="stars" />
 </question>
 ```
 
@@ -237,7 +242,7 @@ Prompts the student to upload a file as their response.
 
 ## `numerical`
 
-Accepts a numerical answer. Supports three modes via `numerical_answer_type`.
+Accepts a numerical answer. Supports three modes via `numerical_answer_type`. Optional per-answer feedback may be provided with `answer_comments` on each `<correct>` tag.
 
 ### Exact Answer
 
@@ -245,7 +250,7 @@ Accepts a numerical answer. Supports three modes via `numerical_answer_type`.
 <question type="numerical" numerical_answer_type="exact">
     What is π?
 
-    <correct answer_exact="3.14159" answer_error_margin="0.0001"/>
+    <correct answer_exact="3.14159" answer_error_margin="0.0001" answer_comments="Rounded correctly." />
 </question>
 ```
 
@@ -255,7 +260,7 @@ Accepts a numerical answer. Supports three modes via `numerical_answer_type`.
 <question type="numerical" numerical_answer_type="range">
     Give a value for x such that 1 ≤ x ≤ 10.
 
-    <correct answer_range_start="1" answer_range_end="10"/>
+    <correct answer_range_start="1" answer_range_end="10" answer_comments="Any value in this interval is accepted." />
 </question>
 ```
 
@@ -265,6 +270,6 @@ Accepts a numerical answer. Supports three modes via `numerical_answer_type`.
 <question type="numerical" numerical_answer_type="precision">
     What is the value of π?
 
-    <correct answer_approximate="3.14159" answer_precision="5"/>
+    <correct answer_approximate="3.14159" answer_precision="5" answer_comments="At least five digits are required." />
 </question>
 ```

--- a/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/skill.md
+++ b/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/skill.md
@@ -31,6 +31,8 @@ The `<quiz>` tag contains two child elements:
 
 - `<description>` — optional instructions shown to students before they begin
 - `<questions>` — required; contains one or more `<question>` tags
+- Some question types support per-answer feedback:
+  `answer_comments` on `<correct>` / `<incorrect>`, and `true_answer_comments` / `false_answer_comments` on `true-false`
 
 ```xml
 <quiz title="Chapter 1 Quiz"
@@ -223,15 +225,16 @@ Use `<overrides>` to set different due dates per course section:
     </description>
 
     <questions>
-        <question type="true-false" answer="true">
+        <question type="true-false" answer="true"
+                  true_answer_comments="Correct" false_answer_comments="The sky is blue under normal daylight conditions.">
             Is the sky blue?
         </question>
 
         <question type="multiple-choice">
             What is the capital of France?
 
-            <correct>Paris</correct>
-            <incorrect>London</incorrect>
+            <correct answer_comments="Exactly right">Paris</correct>
+            <incorrect answer_comments="London is the capital of the UK">London</incorrect>
             <incorrect>Berlin</incorrect>
             <incorrect>Madrid</incorrect>
         </question>
@@ -258,15 +261,16 @@ A minimal working quiz:
     </description>
 
     <questions>
-        <question type="true-false" answer="true">
+        <question type="true-false" answer="true"
+                  true_answer_comments="Correct" false_answer_comments="Python variable names are case-sensitive.">
             Python variable names are case-sensitive.
         </question>
 
         <question type="multiple-choice">
             Which of the following is a valid Python variable name?
 
-            <correct>my_var</correct>
-            <incorrect>2myvar</incorrect>
+            <correct answer_comments="Underscores are allowed after the first character">my_var</correct>
+            <incorrect answer_comments="Variable names cannot start with a number">2myvar</incorrect>
             <incorrect>my-var</incorrect>
             <incorrect>my var</incorrect>
         </question>

--- a/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/skill.md
+++ b/.myteam/mdxcanvas-roster/reference/canvas-tags/quiz/skill.md
@@ -32,7 +32,7 @@ The `<quiz>` tag contains two child elements:
 - `<description>` — optional instructions shown to students before they begin
 - `<questions>` — required; contains one or more `<question>` tags
 - Some question types support per-answer feedback:
-  `answer_comments` on `<correct>` / `<incorrect>`, and `true_answer_comments` / `false_answer_comments` on `true-false`
+  `answer_comments` on `<correct>` / `<incorrect>`, `answer_comments` on `<pair>`, `answer_comments` on `<correct>` for fill-in and numerical questions, `answer_comments` on `<correct>` / `<incorrect>` for `multiple-tf`, and question-level `correct-comments` / `incorrect-comments` on `true-false`
 
 ```xml
 <quiz title="Chapter 1 Quiz"
@@ -226,7 +226,7 @@ Use `<overrides>` to set different due dates per course section:
 
     <questions>
         <question type="true-false" answer="true"
-                  true_answer_comments="Correct" false_answer_comments="The sky is blue under normal daylight conditions.">
+                  correct-comments="Correct" incorrect-comments="The sky is blue under normal daylight conditions.">
             Is the sky blue?
         </question>
 
@@ -262,7 +262,7 @@ A minimal working quiz:
 
     <questions>
         <question type="true-false" answer="true"
-                  true_answer_comments="Correct" false_answer_comments="Python variable names are case-sensitive.">
+                  correct-comments="Correct" incorrect-comments="Python variable names are case-sensitive.">
             Python variable names are case-sensitive.
         </question>
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ Example (`.xml` quiz):
         <question type="multiple-choice">
             Who is the author of the Harry Potter series?
 
-            <correct>J.K. Rowling</correct>
-            <incorrect>J.R.R. Tolkien</incorrect>
+            <correct answer_comments="Correct">J.K. Rowling</correct>
+            <incorrect answer_comments="Tolkien wrote The Lord of the Rings">J.R.R. Tolkien</incorrect>
             <incorrect>George R.R. Martin</incorrect>
             <incorrect>Stephen King</incorrect>
         </question>
 
-        <question type="true-false" answer="true">
+        <question type="true-false" answer="true"
+                  true_answer_comments="Correct" false_answer_comments="Harry is a wizard.">
             Is Harry Potter a wizard?
         </question>
     </questions>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example (`.xml` quiz):
         </question>
 
         <question type="true-false" answer="true"
-                  true_answer_comments="Correct" false_answer_comments="Harry is a wizard.">
+                  correct-comments="Correct" incorrect-comments="Harry is a wizard.">
             Is Harry Potter a wizard?
         </question>
     </questions>

--- a/documents/supported_tags/tags/quiz_question_types.md
+++ b/documents/supported_tags/tags/quiz_question_types.md
@@ -4,6 +4,13 @@ The `<question>` tag is used within the `<questions>` section of a `<quiz>` to d
 
 Each question has a `type` attribute and may include one or more child tags (e.g., `<correct>`, `<incorrect>`, `<pair>`). The content body is treated as the question prompt.
 
+## Answer Feedback
+
+Some question types support per-answer feedback that maps directly to the Canvas API:
+
+- `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` and `<incorrect>`
+- `true-false`: use `true_answer_comments="..."` and `false_answer_comments="..."` on `<question>`
+
 ## Question Types
 
 ### `text`
@@ -19,23 +26,26 @@ Displays a block of instructional or contextual text. It does not require an ans
 ### `true-false`
 
 Presents a True/False question. Requires the `answer` attribute (`true` or `false`).
+Optional per-answer feedback may be provided with `true_answer_comments` and `false_answer_comments`.
 
 ```xml
-<question id="tf_1" type="true-false" answer="true">
+<question id="tf_1" type="true-false" answer="true"
+          true_answer_comments="Correct"
+          false_answer_comments="The sky is blue under normal daylight conditions.">
     Is the sky blue?
 </question>
 ```
 
 ### `multiple-choice`
 
-Creates a single-answer multiple-choice question. Requires at least one `<correct>` and one or more `<incorrect>` options.
+Creates a single-answer multiple-choice question. Requires at least one `<correct>` and one or more `<incorrect>` options. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question id="mc_1" type="multiple-choice">
     What is the capital of France?
 
-    <correct>Paris</correct>
-    <incorrect>London</incorrect>
+    <correct answer_comments="Exactly right">Paris</correct>
+    <incorrect answer_comments="London is the capital of the UK">London</incorrect>
     <incorrect>Berlin</incorrect>
     <incorrect>Madrid</incorrect>
 </question>
@@ -43,15 +53,15 @@ Creates a single-answer multiple-choice question. Requires at least one `<correc
 
 ### `multiple-answers`
 
-Allows selection of multiple correct answers.
+Allows selection of multiple correct answers. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question id="ma_1" type="multiple-answers">
     Which of the following are programming languages?
 
-    <correct>Python</correct>
+    <correct answer_comments="Yes">Python</correct>
     <correct>JavaScript</correct>
-    <incorrect>HTML</incorrect>
+    <incorrect answer_comments="HTML is markup, not a programming language">HTML</incorrect>
     <incorrect>CSS</incorrect>
 </question>
 ```

--- a/documents/supported_tags/tags/quiz_question_types.md
+++ b/documents/supported_tags/tags/quiz_question_types.md
@@ -9,7 +9,7 @@ Each question has a `type` attribute and may include one or more child tags (e.g
 Some question types support per-answer feedback that maps directly to the Canvas API:
 
 - `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` and `<incorrect>`
-- `true-false`: use `true_answer_comments="..."` and `false_answer_comments="..."` on `<question>`
+- `true-false`: use question-level `correct-comments` and `incorrect-comments`
 
 ## Question Types
 
@@ -26,12 +26,12 @@ Displays a block of instructional or contextual text. It does not require an ans
 ### `true-false`
 
 Presents a True/False question. Requires the `answer` attribute (`true` or `false`).
-Optional per-answer feedback may be provided with `true_answer_comments` and `false_answer_comments`.
+Feedback should be provided with the standard question-level `correct-comments` and `incorrect-comments` fields.
 
 ```xml
 <question id="tf_1" type="true-false" answer="true"
-          true_answer_comments="Correct"
-          false_answer_comments="The sky is blue under normal daylight conditions.">
+          correct-comments="Correct"
+          incorrect-comments="The sky is blue under normal daylight conditions.">
     Is the sky blue?
 </question>
 ```

--- a/documents/supported_tags/tags/quiz_question_types.md
+++ b/documents/supported_tags/tags/quiz_question_types.md
@@ -9,6 +9,10 @@ Each question has a `type` attribute and may include one or more child tags (e.g
 Some question types support per-answer feedback that maps directly to the Canvas API:
 
 - `multiple-choice` and `multiple-answers`: use `answer_comments="..."` on `<correct>` and `<incorrect>`
+- `matching`: use `answer_comments="..."` on `<pair>`
+- `fill-in-the-blank` and `fill-in-multiple-blanks`: use `answer_comments="..."` on `<correct>`
+- `numerical`: use `answer_comments="..."` on `<correct>`
+- `multiple-tf`: use `answer_comments="..."` on `<correct>` and `<incorrect>` to populate `correct-comments` on each generated true/false subquestion
 - `true-false`: use question-level `correct-comments` and `incorrect-comments`
 
 ## Question Types
@@ -68,13 +72,13 @@ Allows selection of multiple correct answers. Optional per-answer feedback may b
 
 ### `matching`
 
-Requires students to match items from two columns. Use `<pair>` for correct matches and optionally `<distractors>`.
+Requires students to match items from two columns. Use `<pair>` for correct matches and optionally `<distractors>`. Optional per-pair feedback may be provided with `answer_comments`.
 
 ```xml
 <question id="matching_1" type="matching">
     Match the following countries with their capitals.
 
-    <pair left="France" right="Paris" />
+    <pair left="France" right="Paris" answer_comments="Paris is the capital of France." />
     <pair left="Germany" right="Berlin" />
     <pair left="Spain" right="Madrid" />
 
@@ -88,14 +92,14 @@ Requires students to match items from two columns. Use `<pair>` for correct matc
 
 ### `multiple-tf`
 
-Presents multiple True/False statements. Students select which are true.
+Presents multiple True/False statements. Students select which are true. Optional `answer_comments` on each `<correct>` / `<incorrect>` child becomes question-level feedback on the generated true/false subquestion.
 
 ```xml
 <question id="mtf_1" type="multiple-tf">
     Which of the following statements are true?
 
-    <correct>Python is a programming language.</correct>
-    <incorrect>HTML is a programming language.</incorrect>
+    <correct answer_comments="Yes, Python is a programming language.">Python is a programming language.</correct>
+    <incorrect answer_comments="No, HTML is markup.">HTML is a programming language.</incorrect>
     <correct>JavaScript can be used for web development.</correct>
     <incorrect>CSS is a programming language.</incorrect>
 </question>
@@ -103,25 +107,25 @@ Presents multiple True/False statements. Students select which are true.
 
 ### `fill-in-the-blank`
 
-Creates a single blank the student must fill in. Use `[blank]` in the sentence and `<correct text="..." />` to define valid answers.
+Creates a single blank the student must fill in. Use `[blank]` in the sentence and `<correct text="..." />` to define valid answers. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question id="fitb_1" type="fill-in-the-blank">
     The capital of France is [blank].
 
-    <correct text="Paris" />
+    <correct text="Paris" answer_comments="Exactly right." />
 </question>
 ```
 
 ### `fill-in-multiple-blanks`
 
-Creates multiple blanks identified by name (e.g., `[stars]`). Each `<correct>` must define the matching `blank`.
+Creates multiple blanks identified by name (e.g., `[stars]`). Each `<correct>` must define the matching `blank`. Optional per-answer feedback may be provided with `answer_comments`.
 
 ```xml
 <question id="fimb_1" type="fill-in-multiple-blanks">
     The U.S. flag has [stripes] stripes and [stars] stars.
 
-    <correct text="13" blank="stripes" />
+    <correct text="13" blank="stripes" answer_comments="There are 13 original colonies." />
     <correct text="50" blank="stars" />
 </question>
 ```
@@ -158,7 +162,7 @@ Prompts the student to upload a file as their response.
 
 ### `numerical`
 
-Accepts a numerical answer and supports three modes via `numerical_answer_type`:
+Accepts a numerical answer and supports three modes via `numerical_answer_type`. Optional per-answer feedback may be provided with `answer_comments` on each `<correct>` tag:
 
 #### 1. Exact Answer
 
@@ -166,7 +170,7 @@ Accepts a numerical answer and supports three modes via `numerical_answer_type`:
 <question id="num_exact_1" type="numerical" numerical_answer_type="exact">
     What is π?
 
-    <correct answer_exact="3.14159" answer_error_margin="0.0001" />
+    <correct answer_exact="3.14159" answer_error_margin="0.0001" answer_comments="Rounded correctly." />
 </question>
 ```
 
@@ -176,7 +180,7 @@ Accepts a numerical answer and supports three modes via `numerical_answer_type`:
 <question id="num_range_1" type="numerical" numerical_answer_type="range">
     Give a value for x such that 1 ≤ x ≤ 10.
 
-    <correct answer_range_start="1" answer_range_end="10" />
+    <correct answer_range_start="1" answer_range_end="10" answer_comments="Any value in this interval is accepted." />
 </question>
 ```
 
@@ -186,6 +190,6 @@ Accepts a numerical answer and supports three modes via `numerical_answer_type`:
 <question id="num_precision_1" type="numerical" numerical_answer_type="precision">
     What is the value of π?
 
-    <correct answer_approximate="3.14159" answer_precision="5" />
+    <correct answer_approximate="3.14159" answer_precision="5" answer_comments="At least five digits are required." />
 </question>
 ```

--- a/documents/supported_tags/tags/quiz_tag.md
+++ b/documents/supported_tags/tags/quiz_tag.md
@@ -165,7 +165,9 @@ Required. Contains one or more `<question>` tags.
 
 Each question must define a `type` and may include `<correct>`, `<incorrect>`, `<pair>`, and other tags based on the question type.
 
-See [quiz question types](quiz_question_types.md) for full documentation of supported types and examples.
+Per-answer Canvas feedback is also supported for some question types:
+- `multiple-choice` / `multiple-answers`: `answer_comments` on `<correct>` / `<incorrect>`
+- `true-false`: `true_answer_comments` / `false_answer_comments` on `<question>`
 
 ## Section-Specific Dates
 
@@ -211,15 +213,16 @@ See the [`<override>` tag documentation](override_tag.md) for more details on se
     </description>
 
     <questions>
-        <question id="q1" type="true-false" answer="true">
+        <question id="q1" type="true-false" answer="true"
+                  true_answer_comments="Correct" false_answer_comments="The sky is blue under normal daylight conditions.">
             Is the sky blue?
         </question>
 
         <question id="q2" type="multiple-choice">
             What is the capital of France?
 
-            <correct>Paris</correct>
-            <incorrect>London</incorrect>
+            <correct answer_comments="Exactly right">Paris</correct>
+            <incorrect answer_comments="London is the capital of the UK">London</incorrect>
             <incorrect>Berlin</incorrect>
             <incorrect>Madrid</incorrect>
         </question>
@@ -246,4 +249,4 @@ When you edit an existing quiz that has student submissions, Canvas requires man
 
 Quiz questions are managed in the `<questions>` container and are created/updated as separate resources. Each question requires a unique ID within the quiz scope and a supported `type`. Questions are deployed after the quiz itself is created.
 
-See the [quiz question types documentation](quiz_question_types.md) for complete information on all supported question types and their specific syntax.
+See the [quiz question types documentation](quiz_question_types.md) for complete information on supported question types, including per-answer feedback fields.

--- a/documents/supported_tags/tags/quiz_tag.md
+++ b/documents/supported_tags/tags/quiz_tag.md
@@ -167,6 +167,10 @@ Each question must define a `type` and may include `<correct>`, `<incorrect>`, `
 
 Per-answer Canvas feedback is also supported for some question types:
 - `multiple-choice` / `multiple-answers`: `answer_comments` on `<correct>` / `<incorrect>`
+- `matching`: `answer_comments` on `<pair>`
+- `fill-in-the-blank` / `fill-in-multiple-blanks`: `answer_comments` on `<correct>`
+- `numerical`: `answer_comments` on `<correct>`
+- `multiple-tf`: `answer_comments` on `<correct>` / `<incorrect>` becomes `correct-comments` on each generated true/false subquestion
 - `true-false`: use question-level `correct-comments` / `incorrect-comments`
 
 ## Section-Specific Dates

--- a/documents/supported_tags/tags/quiz_tag.md
+++ b/documents/supported_tags/tags/quiz_tag.md
@@ -167,7 +167,7 @@ Each question must define a `type` and may include `<correct>`, `<incorrect>`, `
 
 Per-answer Canvas feedback is also supported for some question types:
 - `multiple-choice` / `multiple-answers`: `answer_comments` on `<correct>` / `<incorrect>`
-- `true-false`: `true_answer_comments` / `false_answer_comments` on `<question>`
+- `true-false`: use question-level `correct-comments` / `incorrect-comments`
 
 ## Section-Specific Dates
 
@@ -214,7 +214,7 @@ See the [`<override>` tag documentation](override_tag.md) for more details on se
 
     <questions>
         <question id="q1" type="true-false" answer="true"
-                  true_answer_comments="Correct" false_answer_comments="The sky is blue under normal daylight conditions.">
+                  correct-comments="Correct" incorrect-comments="The sky is blue under normal daylight conditions.">
             Is the sky blue?
         </question>
 

--- a/mdxcanvas/xml_processing/quiz_questions.py
+++ b/mdxcanvas/xml_processing/quiz_questions.py
@@ -35,6 +35,15 @@ mostly_common_fields = [
 ]
 
 
+def _maybe_add_answer_comments(answer: dict, tag: Tag | None = None, answer_comments: str | None = None):
+    if answer_comments is None and tag is not None:
+        answer_comments = tag.get('answer_comments')
+
+    if answer_comments:
+        answer['answer_comments'] = answer_comments
+    return answer
+
+
 def parse_text_question(tag: Tag):
     question_text = retrieve_contents(tag)
     question = {
@@ -67,7 +76,9 @@ def parse_true_false_question(tag: Tag):
     </question>
     """
     fields = [
-        Attribute('answer', required=True, parser=parse_bool, default=False)
+        Attribute('answer', required=True, parser=parse_bool, default=False),
+        Attribute('true_answer_comments'),
+        Attribute('false_answer_comments')
     ]
     question = parse_settings(tag, mostly_common_fields + fields)
 
@@ -75,16 +86,19 @@ def parse_true_false_question(tag: Tag):
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": 'true_false_question',
         "answers": [
-            {
+            _maybe_add_answer_comments({
                 "answer_text": "True",
                 "answer_weight": FULL_POINTS if question["answer"] is True else NO_POINTS
-            },
-            {
+            }, answer_comments=question.get('true_answer_comments')),
+            _maybe_add_answer_comments({
                 "answer_text": "False",
                 "answer_weight": FULL_POINTS if question["answer"] is False else NO_POINTS
-            }
+            }, answer_comments=question.get('false_answer_comments'))
         ]
     })
+
+    question.pop('true_answer_comments', None)
+    question.pop('false_answer_comments', None)
 
     return [question]
 
@@ -117,16 +131,15 @@ def parse_multiple_answers_question(tag: Tag):
 
 
 def _parse_multiple_option_question(question_type, tag):
-    corrects = parse_children_tag_contents(tag, 'correct')
-    answers = parse_children_tag_contents(tag, re.compile(r'correct|incorrect'))
+    answers = tag.find_all(re.compile(r'correct|incorrect'), recursive=False)
     question = {
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": question_type,
         "answers": [
-            {
-                "answer_html": answer,
-                "answer_weight": FULL_POINTS if answer in corrects else NO_POINTS
-            } for answer in answers
+            _maybe_add_answer_comments({
+                "answer_html": retrieve_contents(answer),
+                "answer_weight": FULL_POINTS if answer.name == 'correct' else NO_POINTS
+            }, answer) for answer in answers
         ]
     }
     question.update(parse_settings(tag, mostly_common_fields))

--- a/mdxcanvas/xml_processing/quiz_questions.py
+++ b/mdxcanvas/xml_processing/quiz_questions.py
@@ -40,7 +40,8 @@ def _maybe_add_answer_comments(answer: dict, tag: Tag | None = None, answer_comm
         answer_comments = tag.get('answer_comments')
 
     if answer_comments:
-        answer['answer_comments'] = answer_comments
+        answer['comments_html'] = f"<p>{answer_comments}</p>"
+
     return answer
 
 

--- a/mdxcanvas/xml_processing/quiz_questions.py
+++ b/mdxcanvas/xml_processing/quiz_questions.py
@@ -132,7 +132,7 @@ def parse_multiple_answers_question(tag: Tag):
 
 
 def _parse_multiple_option_question(question_type, tag):
-    answers = tag.find_all(re.compile(r'correct|incorrect'), recursive=False)
+    answers = tag.find_all(['correct', 'incorrect'], recursive=False)
     question = {
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": question_type,

--- a/mdxcanvas/xml_processing/quiz_questions.py
+++ b/mdxcanvas/xml_processing/quiz_questions.py
@@ -35,7 +35,7 @@ mostly_common_fields = [
 ]
 
 
-def _maybe_add_answer_comments(answer: dict, tag: Tag | None = None, answer_comments: str | None = None):
+def _add_answer_comments(answer: dict, tag: Tag | None = None, answer_comments: str | None = None):
     if answer_comments is None and tag is not None:
         answer_comments = tag.get('answer_comments')
 
@@ -132,7 +132,7 @@ def _parse_multiple_option_question(question_type, tag):
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": question_type,
         "answers": [
-            _maybe_add_answer_comments({
+            _add_answer_comments({
                 "answer_html": retrieve_contents(answer),
                 "answer_weight": FULL_POINTS if answer.name == 'correct' else NO_POINTS
             }, answer) for answer in answers
@@ -158,11 +158,17 @@ def parse_matching_question(tag: Tag):
     """
     left_field = Attribute('left', required=True)
     right_field = Attribute('right', required=True)
-    pairs = [
-        parse_settings(answer, [left_field, right_field]) for answer in tag.find_all('pair')
-    ]
+    pairs = tag.find_all('pair')
     distractors = '\n'.join(parse_children_tag_contents(tag, 'distractors'))
     distractors = '\n'.join(line for line in distractors.splitlines() if line.split())
+    parsed_pairs = []
+    for pair_tag in pairs:
+        pair = parse_settings(pair_tag, [left_field, right_field])
+        parsed_pairs.append(_add_answer_comments({
+            "answer_match_left": pair['left'],
+            "answer_match_right": pair['right'],
+            "answer_weight": FULL_POINTS
+        }, pair_tag))
 
     question = parse_settings(tag, mostly_common_fields)
 
@@ -170,13 +176,7 @@ def parse_matching_question(tag: Tag):
         "question_text": retrieve_contents(tag, question_children_names + ['pair', 'distractors']),
         "question_type": 'matching_question',
         "points_possible": parse_int(tag.get('points') or len(pairs)),
-        "answers": [
-            {
-                "answer_match_left": answer['left'],
-                "answer_match_right": answer['right'],
-                "answer_weight": FULL_POINTS
-            } for answer in pairs
-        ],
+        "answers": parsed_pairs,
         "matching_answer_incorrect_matches": distractors
     })
 
@@ -223,7 +223,7 @@ def parse_multiple_true_false_question(tag: Tag):
 
     qid = settings['question_id']
     for index, child in enumerate(answers):
-        resulting_questions.append({
+        question = {
             "question_text": retrieve_contents(child),
             "question_type": 'true_false_question',
             "question_id": f'{qid}_{index}',
@@ -238,7 +238,12 @@ def parse_multiple_true_false_question(tag: Tag):
                     "answer_weight": FULL_POINTS if child.name == 'incorrect' else NO_POINTS
                 }
             ]
-        })
+        }
+
+        if answer_comments := child.get('answer_comments'):
+            question['correct_comments'] = answer_comments
+
+        resulting_questions.append(question)
 
     return resulting_questions
 
@@ -334,7 +339,8 @@ def parse_fill_in_the_blank_question(tag: Tag):
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": 'fill_in_multiple_blanks_question',
         "answers": [
-            parse_settings(answer, answer_attributes) for answer in tag.find_all('correct')
+            _add_answer_comments(parse_settings(answer, answer_attributes), answer)
+            for answer in tag.find_all('correct')
         ]
     }
 
@@ -363,7 +369,8 @@ def parse_fill_in_multiple_blanks_question(tag: Tag):
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": 'fill_in_multiple_blanks_question',
         "answers": [
-            parse_settings(answer, answer_attributes) for answer in answers
+            _add_answer_comments(parse_settings(answer, answer_attributes), answer)
+            for answer in answers
         ]
     }
 
@@ -480,7 +487,8 @@ def parse_numerical_question(tag: Tag):
         "question_text": question_text,
         "question_type": 'numerical_question',
         "answers": [
-            parse_settings(answer, answer_attributes) for answer in tag.find_all('correct')
+            _add_answer_comments(parse_settings(answer, answer_attributes), answer)
+            for answer in tag.find_all('correct')
         ]
     }
 

--- a/mdxcanvas/xml_processing/quiz_questions.py
+++ b/mdxcanvas/xml_processing/quiz_questions.py
@@ -66,20 +66,18 @@ def parse_true_false_question(tag: Tag):
     The earth is **flat**
 
     <correct-comments>
-    A nationwide survey in 2022 by researchers at the University of New Hampshire found that
-    10% of U.S. adults believed the earth was flat.
+    Regular folks who like math and stars rely on the curvature on the earth to track the motion
+    of heavenly bodies.
     </correct-comments>
 
     <incorrect-comments>
-    Regular folks who like math and stars rely on the curvature on the earth to track the motion
-    of heavenly bodies.
+    A nationwide survey in 2022 by researchers at the University of New Hampshire found that
+    10% of U.S. adults believed the earth was flat.
     </incorrect-comments>
     </question>
     """
     fields = [
         Attribute('answer', required=True, parser=parse_bool, default=False),
-        Attribute('true_answer_comments'),
-        Attribute('false_answer_comments')
     ]
     question = parse_settings(tag, mostly_common_fields + fields)
 
@@ -87,19 +85,16 @@ def parse_true_false_question(tag: Tag):
         "question_text": retrieve_contents(tag, question_children_names),
         "question_type": 'true_false_question',
         "answers": [
-            _maybe_add_answer_comments({
+            {
                 "answer_text": "True",
                 "answer_weight": FULL_POINTS if question["answer"] is True else NO_POINTS
-            }, answer_comments=question.get('true_answer_comments')),
-            _maybe_add_answer_comments({
+            },
+            {
                 "answer_text": "False",
                 "answer_weight": FULL_POINTS if question["answer"] is False else NO_POINTS
-            }, answer_comments=question.get('false_answer_comments'))
+            }
         ]
     })
-
-    question.pop('true_answer_comments', None)
-    question.pop('false_answer_comments', None)
 
     return [question]
 

--- a/tests/test_quiz_question_parsing.py
+++ b/tests/test_quiz_question_parsing.py
@@ -1,0 +1,121 @@
+from bs4 import BeautifulSoup
+
+from mdxcanvas.xml_processing.quiz_questions import (
+    parse_multiple_answers_question,
+    parse_multiple_choice_question,
+    parse_true_false_question,
+)
+
+
+def _parse_question(xml: str):
+    return BeautifulSoup(xml, 'html.parser').find('question')
+
+
+def test_multiple_choice_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="multiple-choice">
+        What is the capital of France?
+        <correct answer_comments="Exactly right">Paris</correct>
+        <incorrect answer_comments="This is the UK capital">London</incorrect>
+        <incorrect>Berlin</incorrect>
+    </question>
+    """)
+
+    parsed = parse_multiple_choice_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_html': 'Paris',
+            'answer_weight': 100,
+            'answer_comments': 'Exactly right',
+        },
+        {
+            'answer_html': 'London',
+            'answer_weight': 0,
+            'answer_comments': 'This is the UK capital',
+        },
+        {
+            'answer_html': 'Berlin',
+            'answer_weight': 0,
+        },
+    ]
+
+
+def test_multiple_answers_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="multiple-answers">
+        Which are programming languages?
+        <correct answer_comments="Yes">Python</correct>
+        <correct>JavaScript</correct>
+        <incorrect answer_comments="Markup language">HTML</incorrect>
+    </question>
+    """)
+
+    parsed = parse_multiple_answers_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_html': 'Python',
+            'answer_weight': 100,
+            'answer_comments': 'Yes',
+        },
+        {
+            'answer_html': 'JavaScript',
+            'answer_weight': 100,
+        },
+        {
+            'answer_html': 'HTML',
+            'answer_weight': 0,
+            'answer_comments': 'Markup language',
+        },
+    ]
+
+
+def test_true_false_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1"
+              type="true-false"
+              answer="true"
+              true_answer_comments="Correct"
+              false_answer_comments="False is not correct here">
+        The earth orbits the sun.
+    </question>
+    """)
+
+    parsed = parse_true_false_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_text': 'True',
+            'answer_weight': 100,
+            'answer_comments': 'Correct',
+        },
+        {
+            'answer_text': 'False',
+            'answer_weight': 0,
+            'answer_comments': 'False is not correct here',
+        },
+    ]
+
+
+def test_existing_multiple_choice_without_answer_comments_still_parses():
+    question = _parse_question("""
+    <question id="q1" type="multiple-choice">
+        2 + 2 =
+        <correct>4</correct>
+        <incorrect>3</incorrect>
+    </question>
+    """)
+
+    parsed = parse_multiple_choice_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_html': '4',
+            'answer_weight': 100,
+        },
+        {
+            'answer_html': '3',
+            'answer_weight': 0,
+        },
+    ]

--- a/tests/test_quiz_question_parsing.py
+++ b/tests/test_quiz_question_parsing.py
@@ -27,12 +27,12 @@ def test_multiple_choice_answer_comments_are_included():
         {
             'answer_html': 'Paris',
             'answer_weight': 100,
-            'answer_comments': 'Exactly right',
+            'comments_html': '<p>Exactly right</p>',
         },
         {
             'answer_html': 'London',
             'answer_weight': 0,
-            'answer_comments': 'This is the UK capital',
+            'comments_html': '<p>This is the UK capital</p>',
         },
         {
             'answer_html': 'Berlin',
@@ -57,7 +57,7 @@ def test_multiple_answers_answer_comments_are_included():
         {
             'answer_html': 'Python',
             'answer_weight': 100,
-            'answer_comments': 'Yes',
+            'comments_html': '<p>Yes</p>',
         },
         {
             'answer_html': 'JavaScript',
@@ -66,7 +66,7 @@ def test_multiple_answers_answer_comments_are_included():
         {
             'answer_html': 'HTML',
             'answer_weight': 0,
-            'answer_comments': 'Markup language',
+            'comments_html': '<p>Markup language</p>',
         },
     ]
 
@@ -88,12 +88,12 @@ def test_true_false_answer_comments_are_included():
         {
             'answer_text': 'True',
             'answer_weight': 100,
-            'answer_comments': 'Correct',
+            'comments_html': '<p>Correct</p>',
         },
         {
             'answer_text': 'False',
             'answer_weight': 0,
-            'answer_comments': 'False is not correct here',
+            'comments_html': '<p>False is not correct here</p>',
         },
     ]
 

--- a/tests/test_quiz_question_parsing.py
+++ b/tests/test_quiz_question_parsing.py
@@ -71,13 +71,13 @@ def test_multiple_answers_answer_comments_are_included():
     ]
 
 
-def test_true_false_answer_comments_are_included():
+def test_true_false_uses_question_level_feedback_fields():
     question = _parse_question("""
     <question id="q1"
               type="true-false"
               answer="true"
-              true_answer_comments="Correct"
-              false_answer_comments="False is not correct here">
+              correct-comments="Correct"
+              incorrect-comments="False is not correct here">
         The earth orbits the sun.
     </question>
     """)
@@ -88,14 +88,14 @@ def test_true_false_answer_comments_are_included():
         {
             'answer_text': 'True',
             'answer_weight': 100,
-            'comments_html': '<p>Correct</p>',
         },
         {
             'answer_text': 'False',
             'answer_weight': 0,
-            'comments_html': '<p>False is not correct here</p>',
         },
     ]
+    assert parsed['correct_comments'] == 'Correct'
+    assert parsed['incorrect_comments'] == 'False is not correct here'
 
 
 def test_existing_multiple_choice_without_answer_comments_still_parses():

--- a/tests/test_quiz_question_parsing.py
+++ b/tests/test_quiz_question_parsing.py
@@ -1,8 +1,13 @@
 from bs4 import BeautifulSoup
 
 from mdxcanvas.xml_processing.quiz_questions import (
+    parse_fill_in_multiple_blanks_question,
+    parse_fill_in_the_blank_question,
+    parse_matching_question,
     parse_multiple_answers_question,
     parse_multiple_choice_question,
+    parse_multiple_true_false_question,
+    parse_numerical_question,
     parse_true_false_question,
 )
 
@@ -117,5 +122,132 @@ def test_existing_multiple_choice_without_answer_comments_still_parses():
         {
             'answer_html': '3',
             'answer_weight': 0,
+        },
+    ]
+
+
+def test_matching_pair_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="matching">
+        Match the following:
+        <pair left="France" right="Paris" answer_comments="Paris is the capital of France." />
+        <pair left="Germany" right="Berlin" />
+    </question>
+    """)
+
+    parsed = parse_matching_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_match_left': 'France',
+            'answer_match_right': 'Paris',
+            'answer_weight': 100,
+            'comments_html': '<p>Paris is the capital of France.</p>',
+        },
+        {
+            'answer_match_left': 'Germany',
+            'answer_match_right': 'Berlin',
+            'answer_weight': 100,
+        },
+    ]
+
+
+def test_multiple_true_false_answer_comments_become_correct_feedback():
+    question = _parse_question("""
+    <question id="q1" type="multiple-tf">
+        Which statements are true?
+        <correct answer_comments="Yes, Python is a programming language.">Python is a programming language.</correct>
+        <incorrect answer_comments="No, HTML is markup.">HTML is a programming language.</incorrect>
+    </question>
+    """)
+
+    parsed = parse_multiple_true_false_question(question)
+
+    assert parsed[1]['correct_comments'] == 'Yes, Python is a programming language.'
+    assert parsed[1]['answers'] == [
+        {
+            'answer_text': 'True',
+            'answer_weight': 100,
+        },
+        {
+            'answer_text': 'False',
+            'answer_weight': 0,
+        },
+    ]
+    assert parsed[2]['correct_comments'] == 'No, HTML is markup.'
+    assert parsed[2]['answers'] == [
+        {
+            'answer_text': 'True',
+            'answer_weight': 0,
+        },
+        {
+            'answer_text': 'False',
+            'answer_weight': 100,
+        },
+    ]
+
+
+def test_fill_in_the_blank_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="fill-in-the-blank">
+        The capital of France is [blank].
+        <correct text="Paris" answer_comments="Exactly right" />
+    </question>
+    """)
+
+    parsed = parse_fill_in_the_blank_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_text': 'Paris',
+            'blank_id': 'blank',
+            'answer_weight': 100,
+            'comments_html': '<p>Exactly right</p>',
+        },
+    ]
+
+
+def test_fill_in_multiple_blanks_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="fill-in-multiple-blanks">
+        The U.S. flag has [stripes] stripes and [stars] stars.
+        <correct text="13" blank="stripes" answer_comments="There are 13 original colonies." />
+        <correct text="50" blank="stars" />
+    </question>
+    """)
+
+    parsed = parse_fill_in_multiple_blanks_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_text': '13',
+            'blank_id': 'stripes',
+            'answer_weight': 100,
+            'comments_html': '<p>There are 13 original colonies.</p>',
+        },
+        {
+            'answer_text': '50',
+            'blank_id': 'stars',
+            'answer_weight': 100,
+        },
+    ]
+
+
+def test_numerical_answer_comments_are_included():
+    question = _parse_question("""
+    <question id="q1" type="numerical" numerical_answer_type="exact">
+        What is pi to 5 decimal places?
+        <correct answer_exact="3.14159" answer_error_margin="0.00001" answer_comments="Rounded correctly." />
+    </question>
+    """)
+
+    parsed = parse_numerical_question(question)[0]
+
+    assert parsed['answers'] == [
+        {
+            'answer_exact': '3.14159',
+            'answer_error_margin': '0.00001',
+            'numerical_answer_type': 'exact_answer',
+            'comments_html': '<p>Rounded correctly.</p>',
         },
     ]


### PR DESCRIPTION
This updates the XML parsing to read the 'answer_comments' tag on individual questions allowing feedback to be provided on each answer if desired.

While the 'answer_comment' attribute is part of the answer object, Canvas actually needs the text passed in as the 'comment_html' attribute just like answer text is passed as 'answer_html' instead of 'answer_text'.  

This also adds some tests for this feature and updates the documentation.